### PR TITLE
Making event avalible in request object (req.event)

### DIFF
--- a/index.js
+++ b/index.js
@@ -271,7 +271,7 @@ class Router {
      * @returns {Response}
      */
     async handle(event) {
-        const request = { headers: event.request.headers, method: event.request.method, url: event.request.url }
+        const request = { headers: event.request.headers, method: event.request.method, url: event.request.url, event: event }
         request.params = []
         if (request.method === 'OPTIONS' && Object.keys(this.corsConfig).length) {
             return new Response('', {


### PR DESCRIPTION
It's make possible to use the router for another use cases of cloudflare workers, that needs event object.