### PR TITLE
fixed cors response body

### DIFF
--- a/index.js
+++ b/index.js
@@ -298,7 +298,7 @@ class Router {
         const request = { headers: event.request.headers, method: event.request.method, url: event.request.url, event: event }
         request.params = []
         if (request.method === 'OPTIONS' && Object.keys(this.corsConfig).length) {
-            return new Response('', {
+            return new Response(null, {
                 headers: {
                     'Access-Control-Allow-Origin': this.corsConfig.allowOrigin,
                     'Access-Control-Allow-Methods': this.corsConfig.allowMethods,


### PR DESCRIPTION
Changes the default router.cors() to return null as body to prevent wrangler throwing error about non-null response body on every option request:

<code>
Constructing a Response with a null body status (204) and a non-null, zero-length body. This is technically incorrect, and we recommend you update your code to explicitly pass in a `null` body, e.g. `new Response(null, { status: 204, ... })`. (We continue to allow the zero-length body behavior because it was previously the only way to construct a Response with a null body status. This behavior may change in the future.)
</code>