### PR TITLE
Fix issue when returning ReadableStreams and other strange responses

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -53,6 +53,7 @@ declare class Router {
      * @property {Object<string, string>} headers Object you can set response headers in
      * @property {number} status Return status code (default: `204`)
      * @property {Object<string, string>|string} body Either an `object` (will be converted to JSON) or a string
+     * @property {Response} response A response object that is to be returned, this will void all other res properties and return this as is.
      */
     /**
      * Next Function
@@ -290,6 +291,10 @@ type RouterResponse = {
      * Return status code (default: `204`)
      */
     status: number
+    /**
+     * A response object to be directly returned to the client
+     */
+    response: Response
     /**
      * Either an `object` (will be converted to JSON) or a string
      */

--- a/index.js
+++ b/index.js
@@ -358,6 +358,9 @@ class Router {
                     res.headers['Content-Type'] = 'application/json'
                 res.body = JSON.stringify(res.body)
             }
+            if(res.response){
+                return res.response
+            }
             return new Response(res.body, {
                 status: res.status || (res.body ? 200 : 204),
                 headers: res.headers


### PR DESCRIPTION
Hi!
When trying to return a response manually cached to cf caches containing an image (png) I had several issues with the image containing bad data when returning it. This is perhaps a dirty fix for the issue, but at least you can see what my issue was and improve the solution. 