### PR TITLE
Add websocket support

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,11 +138,12 @@ Key       | Type                | Description
 
 ### `res`-Object
 
-Key       | Type                | Description
---------- | ------------------- | -----------
-`body`    | `object` / `string` | Either set an `object` (will be converted to JSON) or a string
-`headers` | `object`            | Object you can set response headers in
-`status`  | `integer`           | Return status code (default: `204`)
+Key         | Type                | Description
+----------- | ------------------- | -----------
+`body`      | `object` / `string` | Either set an `object` (will be converted to JSON) or a string
+`headers`   | `object`            | Object you can set response headers in
+`status`    | `integer`           | Return status code (default: `204`)
+`webSocket` | `WebSocket`         | Upgraded websocket connection
 
 
 ## Setup

--- a/index.d.ts
+++ b/index.d.ts
@@ -302,6 +302,10 @@ type RouterResponse = {
     body: {
         [key: string]: string
     } | string
+    /**
+     * Upgraded websocket connection
+     */
+    webSocket?: WebSocket
 }
 /**
  * Next Function

--- a/index.js
+++ b/index.js
@@ -363,10 +363,17 @@ class Router {
             if (res.raw) {
                 return res.raw
             }
-            return new Response(res.body, {
+
+            const resInit = {
                 status: res.status || (res.body ? 200 : 204),
                 headers: res.headers
-            })
+            }
+
+            if (res.webSocket) {
+                resInit.webSocket = res.webSocket
+            }
+
+            return new Response(res.body, resInit)
         } catch(err) {
             console.error(err)
             return new Response(this.debugMode ? err.stack : '', { status: 500 })


### PR DESCRIPTION
The Cloudflare `Response` constructor's init parameter allows for a `webSocket` property. This PR adds mapping for the `webSocket` from the RouterResponse to the native `Response` object.